### PR TITLE
update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# config
+backend/config.js
+
 # Logs
 logs
 *.log


### PR DESCRIPTION
I see our `.gitignore` has not control to our `config.js`.
It seems we don't need to change the format of  `config.js` in a long time. So if we don't add it to `.gitignore` , it can be easily pushed to our repo with the **github acess auth**.